### PR TITLE
small change to improve compilation error feedback

### DIFF
--- a/src/groovy/org/grails/plugins/coffeescript/CoffeeScriptEngine.groovy
+++ b/src/groovy/org/grails/plugins/coffeescript/CoffeeScriptEngine.groovy
@@ -49,7 +49,10 @@ class CoffeeScriptEngine {
       def result = cx.evaluateString(compileScope, "CoffeeScript.compile(coffeeScriptSrc)", "CoffeeScript compile command", 0, null)       
       return result
     } catch (Exception e) {
-      throw new Exception("CoffeeScript Engine compilation failed.", e)
+      throw new Exception("""
+        CoffeeScript Engine compilation of coffeescript to javascript failed.
+        $e
+        """)
     } finally {
       Context.exit()
     }      


### PR DESCRIPTION
on a compilation error, currently published plugin just displays:

```
Problems compiling CoffeeScript /cs/customerAccount/views.coffee
java.lang.Exception: CoffeeScript Engine compilation failed.
```

the change will include the reason why it failed.
