### PR TITLE
Show compilation error, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,10 @@ Every resource module is compressed to bundle. By default .coffee files are not 
     }
   }
 </pre>
+
+Plugin doesn't apply when you have enabled debug mode for resource plugin:
+<pre>
+grails.resources.debug = true
+</pre>
+
+It's because resource plugin disable processing, when debug is enabled, see [resource plugin docs](http://grails-plugins.github.com/grails-resources/guide/8.%20Debugging.html)

--- a/grails-app/resourceMappers/CoffeeScriptResourceMapper.groovy
+++ b/grails-app/resourceMappers/CoffeeScriptResourceMapper.groovy
@@ -1,6 +1,7 @@
 import org.grails.plugin.resource.mapper.MapperPhase
 import org.codehaus.groovy.grails.commons.GrailsApplication
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware
+import org.mozilla.javascript.EvaluatorException
 
 class CoffeeScriptResourceMapper implements GrailsApplicationAware {
 	def phase = MapperPhase.GENERATION
@@ -35,6 +36,13 @@ class CoffeeScriptResourceMapper implements GrailsApplicationAware {
           Problems compiling CoffeeScript ${resource.originalUrl}
           $e
         """
+        Throwable cause = e
+        while (cause.cause) {
+          cause = cause.cause
+          if (cause instanceof EvaluatorException) {
+            log.error("CoffeeScript compilation error: $cause.message")
+          }
+        }
         e.printStackTrace()
       }
     }


### PR DESCRIPTION
About displaying compilation error: I had 'Problems compiling CoffeeScript' message, but it's really not enought to understand where is this error exactly. Detailed error showed that it's because of CoffeeScript 1.2, that doens't work on my machine (don't know why. it's mac os, java 1.6.0_31. fixed by upgrading to 1.3.1)
